### PR TITLE
Rimosso const_cast (undefined behaviour). Es 3.5 manca la teoria.

### DIFF
--- a/Lezione_03/README.md
+++ b/Lezione_03/README.md
@@ -517,13 +517,6 @@
     int * const C3 (& numero) ;
     int const * const C4 (& C1) ;
     ```
-  * E' possibile rimuovere l’attributo ```const``` mediante il ```const_cast```:
-    ```cpp
-    const int myConst = 5;
-    int* nonConst = const_cast<int*>(&myConst);
-    ```
-    * ```nonConst``` punta alla stessa cella di memoria ```myConst```,
-      ma ne può modificare il contenuto
 
 ![linea](../immagini/linea.png)
 


### PR DESCRIPTION
Rimosso le seguenti righe:

"E' possibile rimuovere l’attributo const mediante il const_cast:
const int myConst = 5;
int* nonConst = const_cast<int*>(&myConst);
nonConst punta alla stessa cella di memoria myConst, ma ne può modificare il contenuto"

in quanto una variabile definita const non può essere modificata (e il const non può essere rimosso). La seguente riga 
*nonConst = 4, per esempio, comporta un undefined behaviour.

L'esercizio 3.5 si basa interamente su questo tipo di conversioni che non sono possibili e bisognerebbe modificarlo o forse toglierlo (dato che viene tolta la parte di teoria corrispondente).

reference:
https://en.cppreference.com/w/cpp/language/const_cast